### PR TITLE
conjurfied.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: metadata
+metadata:
+	@echo "Updating extra-info metadata for bundle"
+	@charm set cs:~bigdata-charmers/bundle/realtime-syslog-analytics conjure-up:='{"friendly-name": "Realtime Syslog Analytics", "version": 1}'
+
+all: metadata

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Deploy this bundle using juju-quickstart:
 
     juju quickstart realtime-syslog-analytics
 
+Alternatively, you can deploy using **conjure-up**
+
+    apt install conjure-up
+    conjure-up analytics
+
 See `juju quickstart --help` for deployment options, including machine
 constraints and how to deploy a locally modified version of the
 `realtime-syslog-analytics` bundle.yaml.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Deploy this bundle using juju-quickstart:
 Alternatively, you can deploy using **conjure-up**
 
     apt install conjure-up
-    conjure-up analytics
+    conjure-up bigdata-syslog-analytics
 
 See `juju quickstart --help` for deployment options, including machine
 constraints and how to deploy a locally modified version of the

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -72,6 +72,5 @@ relations:
 description: |
   This spell provides a big data environment for analysing syslog events. Built around Apache Hadoop components, it offers a repeatable and reliable way to setup complex software across multiple substrates.
 tags:
-  - conjure-up-analytics
-  - conjure-up-hadoop
+  - conjure-up-bigdata-syslog-analytics
   - conjure-up-bigdata

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -69,3 +69,9 @@ relations:
   - [rsyslog-forwarder, flume-syslog]
   - [spark, plugin]
   - [zeppelin, spark]
+description: |
+  This spell provides a big data environment for analysing syslog events. Built around Apache Hadoop components, it offers a repeatable and reliable way to setup complex software across multiple substrates.
+tags:
+  - conjure-up-analytics
+  - conjure-up-hadoop
+  - conjure-up-bigdata

--- a/conjure/metadata.json
+++ b/conjure/metadata.json
@@ -1,0 +1,7 @@
+{
+    "friendly-name": "Realtime Syslog Analytics",
+    "version": 1,
+    "options-whitelist": {
+        "spark": ["spark_execution_mode"]
+    }
+}

--- a/conjure/steps/00_deploy-done
+++ b/conjure/steps/00_deploy-done
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Global imports
+import sys
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+NUM_AGENTS = 8
+
+
+def main():
+    log.debug("Running deploy-done for Realtime "
+              "syslog analytics installation.")
+    agent_states = juju.agent_states()
+
+    errored_units = [(unit_name, message) for unit_name, state, message
+                     in agent_states if state == "error"]
+    if len(errored_units) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
+        error('Deployment errors:\n{}'.format(errs))
+
+    machines = juju.machine_states()
+    errored_machines = [(name, err) for name, status, err in machines
+                        if status == "error"]
+    if len(errored_machines) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
+        error("Machine creation errors:\n{}".format(errs))
+
+    # 13 total agents for this spell
+    if len(agent_states) < NUM_AGENTS:
+        fail('{} applications are still deploying'.format(
+            NUM_AGENTS - len(agent_states)))
+
+    # Ganglia does not use the normal status-set 'active' so we skip their
+    # workload status when checking all agent states.
+    active_states = [state == 'active' for _, state, _ in agent_states
+                     if state != 'unknown']
+    if len(active_states) > 0 and all(active_states):
+        success('Applications are ready')
+
+    fail('Applications not ready yet')
+
+
+if __name__ == "__main__":
+    main()

--- a/conjure/steps/00_deploy-done
+++ b/conjure/steps/00_deploy-done
@@ -29,13 +29,13 @@ def main():
         errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
         error("Machine creation errors:\n{}".format(errs))
 
-    # 13 total agents for this spell
+    # 8 total agents for this spell
     if len(agent_states) < NUM_AGENTS:
         fail('{} applications are still deploying'.format(
             NUM_AGENTS - len(agent_states)))
 
-    # Ganglia does not use the normal status-set 'active' so we skip their
-    # workload status when checking all agent states.
+    # In case some services do not support latest status-set command
+    # they will be seen as unknown
     active_states = [state == 'active' for _, state, _ in agent_states
                      if state != 'unknown']
     if len(active_states) > 0 and all(active_states):

--- a/conjure/steps/step-01_namenode_smoketest
+++ b/conjure/steps/step-01_namenode_smoketest
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('namenode')

--- a/conjure/steps/step-01_namenode_smoketest.yaml
+++ b/conjure/steps/step-01_namenode_smoketest.yaml
@@ -1,0 +1,4 @@
+title: Hadoop Namenode Test
+description: |
+  Run a smoke test to validate Apache Hadoop Namenode component.
+viewable: True

--- a/conjure/steps/step-02_resourcemanager_test
+++ b/conjure/steps/step-02_resourcemanager_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('resourcemanager')

--- a/conjure/steps/step-02_resourcemanager_test.yaml
+++ b/conjure/steps/step-02_resourcemanager_test.yaml
@@ -1,0 +1,4 @@
+title: Hadoop ResourceManager Test
+description: |
+  Run a smoke test to validate Apache Hadoop ResourceManager component.
+viewable: True

--- a/conjure/steps/step-03_spark_test
+++ b/conjure/steps/step-03_spark_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('spark')

--- a/conjure/steps/step-03_spark_test.yaml
+++ b/conjure/steps/step-03_spark_test.yaml
@@ -1,0 +1,4 @@
+title: Apache Spark Test
+description: |
+  Run a smoke test to validate Apache Spark component.
+viewable: True

--- a/conjure/steps/step-04_zeppelin_test
+++ b/conjure/steps/step-04_zeppelin_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('zeppelin')

--- a/conjure/steps/step-04_zeppelin_test.yaml
+++ b/conjure/steps/step-04_zeppelin_test.yaml
@@ -1,0 +1,4 @@
+title: Apache Zeppelin Test
+description: |
+  Run a smoke test to validate Apache Zeppelin component.
+viewable: True

--- a/conjure/steps/step-05_zeppelin
+++ b/conjure/steps/step-05_zeppelin
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import sys
+from subprocess import run, DEVNULL, PIPE
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+if __name__ == "__main__":
+    status = juju.status()
+    applications = status['applications']['spark']
+    zeppelin_ip = applications['units']['spark/0']['public-address']
+    if zeppelin_ip:
+        sh = run('juju expose zeppelin', shell=True,
+                 stderr=PIPE,
+                 stdout=DEVNULL)
+        if sh.returncode > 0:
+            error("Failed to expose Zeppelin UI: {}".format(
+                sh.stderr.decode()))
+        success("Zeppelin UI is now configured "
+                "and can be viewed at http://{}:9090".format(zeppelin_ip))
+    fail("Unable to determine Zeppelin UI URL")

--- a/conjure/steps/step-05_zeppelin.yaml
+++ b/conjure/steps/step-05_zeppelin.yaml
@@ -1,0 +1,4 @@
+title: Zeppelin Web UI
+description: |
+  Configure Zeppelin UI for interactive data analytics
+viewable: True

--- a/conjure/steps/utils.py
+++ b/conjure/steps/utils.py
@@ -1,0 +1,54 @@
+from subprocess import run, PIPE
+import yaml
+import sys
+import time
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+def run_smoke_test(service):
+    is_complete = False
+    sh = run('juju run-action {}/0 smoke-test'.format(service),
+             shell=True,
+             stdout=PIPE)
+    run_action_output = yaml.load(sh.stdout.decode())
+    log.debug("{}: {}".format(sh.args, run_action_output))
+    action_id = run_action_output.get('Action queued with id', None)
+    log.debug("Found action: {}".format(action_id))
+    if not action_id:
+        fail("Could not determine action id for smoke-test")
+
+    while not is_complete:
+        sh = run('juju show-action-output {}'.format(action_id),
+                 shell=True,
+                 stderr=PIPE,
+                 stdout=PIPE)
+        log.debug(sh)
+        try:
+            output = yaml.load(sh.stdout.decode())
+            log.debug(output)
+        except Exception as e:
+            log.debug(e)
+        if output['status'] == 'running' or output['status'] == 'pending':
+            time.sleep(5)
+            continue
+        if output['status'] == 'failed':
+            fail("The smoke-test failed, "
+                 "please have a look at `juju show-action-status`")
+        if output['status'] == 'completed':
+            completed_msg = "{} smoke-test passed".format(service)
+            results = output.get('results', None)
+            if not results:
+                is_complete = True
+                success(completed_msg)
+            if results.get('outcome', None):
+                is_complete = True
+                completed_msg = "{}: (result) {}".format(
+                    completed_msg,
+                    results.get('outcome'))
+                success(completed_msg)
+    fail("There is an unknown issue with running the smoke-test, "
+         "please have a look at `juju show-action-status`")


### PR DESCRIPTION
This allows this bundle to be deployed via conjure-up and labels this as a spell. Additional tasks are also performed once deployment is complete. Specifically, running the smoke-tests and providing the user with a URL to view Zeppelin UI.

You can test this yourself by checking out this branch and adding the following:

```
$ sudo apt-add-repository ppa:conjure-up/daily-git
$ sudo apt-add-repository ppa:juju/devel
$ sudo apt update
$ sudo apt install conjure-up
$ cd <location of checked out branch>
$ conjure-up -d .
```

Logs are stored in /var/log/conjure-up in this case it would be /var/log/conjure-up/bundle-realtime-syslog-analytics.log.

Once this is approved and uploaded to the charm store we have a Makefile target you can run to update the necessary metadata information for this bundle to be accessible by conjure-up <spell>. For example,

```
make metadata
<does charm set...>
```

Then users can do keyword searches for spells:

```
conjure-up bigdata
conjure-up hadoop
conjure-up analytics
```

These keywords will search the relevant tags and present the user with a list of possible spells they can deploy.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
